### PR TITLE
Fixes for token and scope to allow Inference API client to introspect the user access token

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -352,6 +352,12 @@ GLOBUS_REDIRECT_URI = PersistentConfig(
     os.environ.get("GLOBUS_REDIRECT_URI", ""),
 )
 
+GLOBUS_INFERENCE_SERVICE_SCOPE = PersistentConfig(
+    "GLOBUS_INFERENCE_SERVICE_SCOPE",
+    "oauth.globus.inference_service_scope",
+    os.environ.get("GLOBUS_INFERENCE_SERVICE_SCOPE", ""),
+)
+
 MICROSOFT_CLIENT_ID = PersistentConfig(
     "MICROSOFT_CLIENT_ID",
     "oauth.microsoft.client_id",

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -882,7 +882,10 @@ async def generate_chat_completion(
         request_url = f"{request_url}/chat/completions?api-version={api_version}"
     else:
         request_url = f"{url}/chat/completions"
-        headers["Authorization"] = f"Bearer {key}"
+        # [Edits]
+        # Using the user's access token with the inference service scope as the API key
+        #headers["Authorization"] = f"Bearer {key}"
+        headers["Authorization"] = f"Bearer {user.api_key}"
 
     payload = json.dumps(payload)
     

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -37,6 +37,7 @@ from open_webui.config import (
     OAUTH_UPDATE_PICTURE_ON_LOGIN,
     WEBHOOK_URL,
     JWT_EXPIRES_IN,
+    GLOBUS_INFERENCE_SERVICE_SCOPE,
     AppConfig,
 )
 from open_webui.constants import ERROR_MESSAGES, WEBHOOK_MESSAGES
@@ -353,8 +354,17 @@ class OAuthManager:
             raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
         
         # [Addition]
-        # Try to extract the access token
-        user_access_token = token.get("access_token", None)
+        # Try to extract the access token issued by the WebUI Globus confidential client
+        # You need to select the access token tied to the inference service's scope
+        # Otherwise the Inference API confidential client won't have the permission to introspect the token
+        user_access_token = None
+        try:
+            user_other_tokens = token["other_tokens"]
+            for other_token in user_other_tokens:
+                if other_token["scope"] == GLOBUS_INFERENCE_SERVICE_SCOPE.value:
+                    user_access_token = other_token["access_token"]
+        except:
+            user_access_token = None
 
         user_data: UserInfo = token.get("userinfo")
         if not user_data or auth_manager_config.OAUTH_EMAIL_CLAIM not in user_data:


### PR DESCRIPTION
* Extracting the right access token from the user (the one that can be introspected by the inference API client)
* New env variable (GLOBUS_INFERENCE_SERVICE_SCOPE) to specify the Globus inference scope
* Now using the user's access token as the API key for chat/completions requests 